### PR TITLE
zero-234: Update secret name to reflect recent changes

### DIFF
--- a/templates/kubernetes/base/deployment.yml
+++ b/templates/kubernetes/base/deployment.yml
@@ -66,7 +66,7 @@ spec:
             valueFrom:
                 secretKeyRef:
                   name: cf-keypair
-                  key: secret_key
+                  key: private_key
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
https://app.zenhub.com/workspaces/commit-zero-5da8decc7046a60001c6db44/issues/commitdev/zero/234

zero-aws-eks-stack sets the secrets with key names of:
    - keypair_id
    - private_key
'private_key' used to be set as 'keypair_secret'; this commit updates zero-deployable-node-backend to be compatible