### PR TITLE
Oathkeeper rules

### DIFF
--- a/templates/.circleci/config.yml
+++ b/templates/.circleci/config.yml
@@ -252,7 +252,7 @@ jobs:
             cd kubernetes/overlays/<< parameters.config-environment >>
             IMAGE=<< parameters.account-id >>.dkr.ecr.<< parameters.region >>.amazonaws.com/<< parameters.repo >>
             kustomize edit set image fake-image=${IMAGE}:${VERSION_TAG}
-            kustomize build . | kubectl apply -f - -n $NAMESPACE
+            kustomize build . | kubectl apply -f -
             if ! kubectl -n $NAMESPACE rollout status deployment/$DEPLOYMENT -w --timeout=180s ; then
               echo "$DEPLOYMENT rollout check failed:"
               echo "$DEPLOYMENT deployment:"

--- a/templates/kubernetes/base/auth.yml
+++ b/templates/kubernetes/base/auth.yml
@@ -1,0 +1,87 @@
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: kratos-public
+spec:
+  upstream:
+    url: http://kratos-public.user-auth
+    stripPath: /.ory/kratos/public
+    preserveHost: true
+  match:
+    #url: http://<backend_service_domain>/.ory/kratos/public/<.*>
+    methods:
+      - GET
+      - POST
+      - PUT
+      - DELETE
+      - PATCH
+  authenticators:
+    - handler: noop
+  authorizer:
+    handler: allow
+  mutators:
+    - handler: noop
+---
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: kratos-form-data
+spec:
+  upstream:
+    url: http://kratos-admin.user-auth
+    stripPath: /.ory/kratos
+    preserveHost: true
+  match:
+    #url: http://<backend_service_domain>/.ory/kratos/self-service/<(login|registration|recovery|settings)>/flows<.*>
+    methods:
+      - GET
+  authenticators:
+    - handler: noop
+  authorizer:
+    handler: allow
+  mutators:
+    - handler: noop
+---
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: public-backend-endpoints
+spec:
+  version: test
+  upstream:
+    url: http://<% .Name %>.<% .Name %>
+    preserveHost: true
+  match:
+    # url: http://<backend_service_domain>/status/<.*>
+    methods:
+      - GET
+      - POST
+  authenticators:
+    - handler: noop
+  authorizer:
+    handler: allow
+  mutators:
+    - handler: noop
+---
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: authenticated-backend-endpoints
+spec:
+  version: test
+  upstream:
+    preserveHost: true
+    url: http://<% .Name %>.<% .Name %>
+    stripPath: /api
+  match:
+    # url: <backend_service_domain>/api/<.*>
+    methods:
+      - GET
+      - POST
+  authenticators:
+    - handler: cookie_session
+  authorizer:
+    handler: allow
+  mutators:
+    - handler: id_token
+    - handler: header

--- a/templates/kubernetes/base/kustomization.yml
+++ b/templates/kubernetes/base/kustomization.yml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: <% .Name %>
+
 resources:
 - deployment.yml
 - service.yml

--- a/templates/kubernetes/overlays/production/auth.yml
+++ b/templates/kubernetes/overlays/production/auth.yml
@@ -1,0 +1,31 @@
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: kratos-public
+spec:
+  match:
+    url: http://<% index .Params `productionBackendSubdomain` %><% index .Params `productionHostRoot` %>/.ory/kratos/public/<.*>
+---
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: kratos-form-data
+spec:
+  match:
+    url: http://<% index .Params `productionBackendSubdomain` %><% index .Params `productionHostRoot` %>/.ory/kratos/self-service/<(login|registration|recovery|settings)>/flows<.*>
+---
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: public-backend-endpoints
+spec:
+  match:
+    url: http://<% index .Params `productionBackendSubdomain` %><% index .Params `productionHostRoot` %>/<(?!(api|\.ory\/kratos)).*>
+---
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: authenticated-backend-endpoints
+spec:
+  match:
+    url: http://<% index .Params `productionBackendSubdomain` %><% index .Params `productionHostRoot` %>/api/<.*>

--- a/templates/kubernetes/overlays/production/ingress.yml
+++ b/templates/kubernetes/overlays/production/ingress.yml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: <% .Name %>
+  namespace: <% .Name %>
   annotations:
     # nginx ingress
     kubernetes.io/ingress.class: nginx

--- a/templates/kubernetes/overlays/production/kustomization.yml
+++ b/templates/kubernetes/overlays/production/kustomization.yml
@@ -3,11 +3,13 @@ kind: Kustomization
 
 patchesStrategicMerge:
 - deployment.yml
-
+<%if eq (index .Params `userAuth`) "yes" %>- auth.yml
+<% end %>
 resources:
 - ../../base
-- ingress.yml
-- pdb.yml
+<%if eq (index .Params `userAuth`) "yes" %>#<% end %>- ingress.yml
+<%if eq (index .Params `userAuth`) "yes" %>- auth.yml
+<% end %>
 
 configMapGenerator:
 - name: <% .Name %>-config

--- a/templates/kubernetes/overlays/production/pdb.yml
+++ b/templates/kubernetes/overlays/production/pdb.yml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: <% .Name %>
+  namespace: <% .Name %>
 spec:
   minAvailable: 2
   selector:

--- a/templates/kubernetes/overlays/staging/auth.yml
+++ b/templates/kubernetes/overlays/staging/auth.yml
@@ -1,0 +1,31 @@
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: kratos-public
+spec:
+  match:
+    url: http://<% index .Params `stagingBackendSubdomain` %><% index .Params `stagingHostRoot` %>/.ory/kratos/public/<.*>
+---
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: kratos-form-data
+spec:
+  match:
+    url: http://<% index .Params `stagingBackendSubdomain` %><% index .Params `stagingHostRoot` %>/.ory/kratos/self-service/<(login|registration|recovery|settings)>/flows<.*>
+---
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: public-backend-endpoints
+spec:
+  match:
+    url: http://<% index .Params `stagingBackendSubdomain` %><% index .Params `stagingHostRoot` %>/<(?!(api|\.ory\/kratos)).*>
+---
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: authenticated-backend-endpoints
+spec:
+  match:
+    url: http://<% index .Params `stagingBackendSubdomain` %><% index .Params `stagingHostRoot` %>/api/<.*>

--- a/templates/kubernetes/overlays/staging/ingress.yml
+++ b/templates/kubernetes/overlays/staging/ingress.yml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: <% .Name %>
+  namespace: <% .Name %>
   annotations:
     # nginx ingress
     kubernetes.io/ingress.class: nginx

--- a/templates/kubernetes/overlays/staging/kustomization.yml
+++ b/templates/kubernetes/overlays/staging/kustomization.yml
@@ -3,10 +3,13 @@ kind: Kustomization
 
 patchesStrategicMerge:
 - deployment.yml
-
+<%if eq (index .Params `userAuth`) "yes" %>- auth.yml
+<% end %>
 resources:
 - ../../base
-- ingress.yml
+<%if eq (index .Params `userAuth`) "yes" %>#<% end %>- ingress.yml
+<%if eq (index .Params `userAuth`) "yes" %>- auth.yml
+<% end %>
 
 configMapGenerator:
 - name: <% .Name %>-config

--- a/zero-module.yml
+++ b/zero-module.yml
@@ -103,3 +103,6 @@ conditions:
     data:
     - src/middleware/auth
     - src/app/auth
+    - kubernetes/base/auth.yml
+    - kubernetes/overlays/staging/auth.yml
+    - kubernetes/overlays/production/auth.yml


### PR DESCRIPTION
merging to feature branch `example-private-data` 

**unresolved things**
- [x] add namespace in `base` kustomization
- [x] auth folder for kustomization in `user-auth` namespace
- [x] overriding urls  in overlays
- [x] circleCI to let manifest declare namespace
- [ ] without `/status` for public path kratos 500 all the routes as it matches more than one rule