### PR TITLE
fix: missing env-vars for gha script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ RANDOM_SEED := ${randomSeed}
 REGION := ${region}
 PROJECT_NAME := ${PROJECT_NAME}
 
+.EXPORT_ALL_VARIABLES:
+
 run: ci_setup
 	@echo "\nDone"
 


### PR DESCRIPTION
go-backend has this export env-vars so the subsequence scripts shares the env-vars
node-backend is missing this